### PR TITLE
今月の予測射数と実測射数の表示を追加

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -5,6 +5,8 @@ class PracticesController < ApplicationController
   # GET /practices or /practices.json
   def index
     @practices = Practice.all
+    @prospects = Prospect.all
+    @results = Practice.sum(:shooting_count)
   end
 
   # GET /practices/1 or /practices/1.json

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -5,8 +5,9 @@ class PracticesController < ApplicationController
   # GET /practices or /practices.json
   def index
     @practices = Practice.all
-    @prospects = Prospect.all
-    @results = Practice.sum(:shooting_count)
+    start_date = params.fetch(:start_date, Date.today).to_date
+    @prospects = Prospect.where(year: start_date.year, month: start_date.month).sum(:total)
+    @results = Practice.where(date: start_date.in_time_zone.all_month).sum(:shooting_count)
   end
 
   # GET /practices/1 or /practices/1.json

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -1,3 +1,7 @@
 class Practice < ApplicationRecord
   belongs_to :user
+
+  def start_time
+    date
+  end
 end

--- a/app/models/prospect.rb
+++ b/app/models/prospect.rb
@@ -1,0 +1,2 @@
+class Prospect < ApplicationRecord
+end

--- a/app/models/prospect.rb
+++ b/app/models/prospect.rb
@@ -1,2 +1,3 @@
 class Prospect < ApplicationRecord
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_many :practices, dependent: :destroy
+  has_many :prospects, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/practices/index.html.erb
+++ b/app/views/practices/index.html.erb
@@ -4,23 +4,19 @@
 
 <hr>
 
-<%= @prospects[0]['year'] %>.<%= @prospects[0]['month'] %>
-<br>
-計：<%= @results %>射／予測：<%= @prospects[0]['total'] %>射
-
-<hr>
-
 <%= link_to "今日の練習を記録する", new_practice_path %>
 
 <hr>
 
-<%= month_calendar(attribute: :date, events: @practices) do |date, practices| %>
-  <%= date.day %>
+<%= turbo_frame_tag 'calendar' do %>
+  <%= month_calendar(attribute: :date, events: @practices) do |date, practices| %>
+    <%= date.day %>
 
-  <% practices.each do |practice| %>
-    <div>
-      <%= practice.shooting_count %>射
-    </div>
+    <% practices.each do |practice| %>
+      <div>
+        <%= practice.shooting_count %>射
+      </div>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/views/practices/index.html.erb
+++ b/app/views/practices/index.html.erb
@@ -4,6 +4,12 @@
 
 <hr>
 
+<%= @prospects[0]['year'] %>.<%= @prospects[0]['month'] %>
+<br>
+計：<%= @results %>射／予測：<%= @prospects[0]['total'] %>射
+
+<hr>
+
 <%= link_to "今日の練習を記録する", new_practice_path %>
 
 <hr>

--- a/app/views/practices/index.html.erb
+++ b/app/views/practices/index.html.erb
@@ -9,8 +9,8 @@
 <hr>
 
 <%= turbo_frame_tag 'calendar' do %>
-  <%= month_calendar(attribute: :date, events: @practices) do |date, practices| %>
-    <%= date.day %>
+  <%= month_calendar(events: @practices) do |date, practices| %>
+    <%= date.month %>/<%= date.day %>
 
     <% practices.each do |practice| %>
       <div>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,4 +1,9 @@
 <div class="simple-calendar">
+  <div>
+    <span class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></span>
+    <p>計：<%= @results %>射／予測：<%= @prospects[0]['total'] %>射</p>
+    <hr>
+  </div>
   <div class="calendar-heading">
     <%= link_to t('simple_calendar.previous', default: 'Previous'), calendar.url_for_previous_view %>
     <span class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></span>

--- a/app/views/simple_calendar/_month_calendar.html.erb
+++ b/app/views/simple_calendar/_month_calendar.html.erb
@@ -1,7 +1,7 @@
 <div class="simple-calendar">
   <div>
     <span class="calendar-title"><%= t('date.month_names')[start_date.month] %> <%= start_date.year %></span>
-    <p>計：<%= @results %>射／予測：<%= @prospects[0]['total'] %>射</p>
+    <p>計：<%= @results %>射／予測：<%= @prospects %>射</p>
     <hr>
   </div>
   <div class="calendar-heading">

--- a/db/migrate/20221011091921_create_prospects.rb
+++ b/db/migrate/20221011091921_create_prospects.rb
@@ -1,0 +1,13 @@
+class CreateProspects < ActiveRecord::Migration[7.0]
+  def change
+    create_table :prospects do |t|
+      t.integer :total
+      t.integer :year, null: false
+      t.integer :month, null: false
+      t.references :user, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :prospects, %i[year month], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_05_064902) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_11_091921) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,17 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_05_064902) do
     t.bigint "user_id"
     t.index ["date"], name: "index_practices_on_date", unique: true
     t.index ["user_id"], name: "index_practices_on_user_id"
+  end
+
+  create_table "prospects", force: :cascade do |t|
+    t.integer "total"
+    t.integer "year", null: false
+    t.integer "month", null: false
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_prospects_on_user_id"
+    t.index ["year", "month"], name: "index_prospects_on_year_and_month", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -54,4 +65,5 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_05_064902) do
   end
 
   add_foreign_key "practices", "users"
+  add_foreign_key "prospects", "users"
 end

--- a/spec/models/prospect_spec.rb
+++ b/spec/models/prospect_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Prospect, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
今月の予測射数と実測射数の表示を追加した。
- Prospectモデルの追加
- Simple CalendarをHotwireを使用する方法に変更
- 予測射数と実測射数をSimple Calendarと連動して変わるようにした

### 関連Issue
#25 