### PR TITLE
固定メモを上部に表示するようにした

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -5,7 +5,7 @@ class PracticesController < ApplicationController
   # GET /practices or /practices.json
   def index
     practices = params[:memos] == 'important' ? Practice.where(important: true) : Practice.all
-    @practices = practices.order(date: :desc).page(params[:page]).per(10)
+    @practices = practices.order(fixed: :desc, date: :desc).page(params[:page]).per(10)
     start_date = params.fetch(:start_date, Date.today).to_date
     @targets = Target.where(year: start_date.year, month: start_date.month).sum(:total)
     @results = Practice.where(date: start_date.in_time_zone.all_month).sum(:shooting_count)


### PR DESCRIPTION
`fixed`フラグがtrueのメモを一覧の一番上に固定表示するようにした。
複数ある場合は日付の新しい順となる。

## 関連Issue
- #38 