### PR TITLE
メモ一覧のリンクのTurboを解除した

### DIFF
--- a/app/views/practices/index.html.erb
+++ b/app/views/practices/index.html.erb
@@ -32,8 +32,8 @@
     <% @practices.each do |practice| %>
       <%= render practice %>
       <p>
-        <%= link_to "詳細", practice %> |
-        <%= link_to "編集", edit_practice_path(practice) %>
+        <%= link_to "詳細", practice, data: { turbo: false} %> |
+        <%= link_to "編集", edit_practice_path(practice), data: { turbo: false} %>
       </p>
       <hr>
     <% end %>


### PR DESCRIPTION
ペーパープロトタイプ作成時に、メモ入力・編集は別画面に遷移した方がしっかり入力できるのでは、という指摘があったため、メモ一覧のリンクのTurboを解除し、別画面に遷移して編集できるようにした。