### PR TITLE
カレンダーをクリックして過去の記録をモーダル表示できるようにした

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -58,7 +58,7 @@ class PracticesController < ApplicationController
     @practice.destroy
 
     respond_to do |format|
-      format.html { redirect_to practices_url, notice: "Practice was successfully destroyed." }
+      format.html { redirect_to practices_url, notice: "Practice was successfully destroyed.", status: :see_other }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -31,7 +31,7 @@ class PracticesController < ApplicationController
 
     respond_to do |format|
       if @practice.save
-        format.html { redirect_to practice_url(@practice), notice: "Practice was successfully created." }
+        format.html { redirect_to practices_path, notice: "Practice was successfully created." }
         format.json { render :show, status: :created, location: @practice }
       else
         format.html { render :new, status: :unprocessable_entity }
@@ -44,7 +44,7 @@ class PracticesController < ApplicationController
   def update
     respond_to do |format|
       if @practice.update(practice_params)
-        format.html { redirect_to practice_url(@practice), notice: "Practice was successfully updated." }
+        format.html { redirect_to practices_path, notice: "Practice was successfully updated." }
         format.json { render :show, status: :ok, location: @practice }
       else
         format.html { render :edit, status: :unprocessable_entity }

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -6,6 +6,7 @@ class PracticesController < ApplicationController
   def index
     practices = params[:memos] == 'important' ? Practice.where(important: true) : Practice.all
     @practices = practices.order(fixed: :desc, date: :desc).page(params[:page]).per(10)
+    @calendar_displayed_practices = Practice.all
     start_date = params.fetch(:start_date, Date.today).to_date
     @targets = Target.where(year: start_date.year, month: start_date.month).sum(:total)
     @results = Practice.where(date: start_date.in_time_zone.all_month).sum(:shooting_count)

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -3,7 +3,7 @@ import { Application } from "@hotwired/stimulus"
 const application = Application.start()
 
 // Configure Stimulus development experience
-application.debug = false
+application.debug = true
 window.Stimulus   = application
 
 export { application }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,5 +4,5 @@
 
 import { application } from "./application"
 
-import HelloController from "./hello_controller"
-application.register("hello", HelloController)
+import ModalController from "./modal_controller"
+application.register("modal", ModalController)

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,7 +1,10 @@
 import { Controller } from "@hotwired/stimulus"
 
+import { Modal } from "bootstrap"
+
 export default class extends Controller {
   connect() {
-    this.element.textContent = "Hello World!"
+    this.modal = new Modal(this.element)
+    this.modal.show()
   }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,5 +28,6 @@
     <p class="notice"><%= notice %></p>
     <p class="alert"><%= alert %></p>
     <%= yield %>
+    <%= turbo_frame_tag "modal" %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
   <head>
     <title>KyudoTrainingLog</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="turbo-cache-control" content="no-cache">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/practices/_modal.html.erb
+++ b/app/views/practices/_modal.html.erb
@@ -1,0 +1,15 @@
+<%= turbo_frame_tag "modal" do %>
+  <div class="modal fade" data-controller="modal">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">モーダル</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <%= yield %>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/practices/_modal.html.erb
+++ b/app/views/practices/_modal.html.erb
@@ -3,8 +3,8 @@
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title">モーダル</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          <h5 class="modal-title"><%= @practice.date %>の記録</h5>
+          <%= button_to '閉じる', practices_path, method: :get, data: { turbo_frame: "_top" } %>
         </div>
         <div class="modal-body">
           <%= yield %>

--- a/app/views/practices/edit.html.erb
+++ b/app/views/practices/edit.html.erb
@@ -5,6 +5,5 @@
 <br>
 
 <div>
-  <%= link_to "詳細", @practice %> |
-  <%= link_to "一覧に戻る", practices_path %>
+  <%= link_to "一覧に戻る", practices_path, data: { turbo_frame: "_top" } %>
 </div>

--- a/app/views/practices/index.html.erb
+++ b/app/views/practices/index.html.erb
@@ -17,7 +17,7 @@
       <div>
         <%= link_to "#{calendar_displayed_practice.shooting_count}射",
                     practice_path(calendar_displayed_practice),
-                    data: { turbo_frame: "_top" } %>
+                    data: { turbo_frame: "modal" } %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/practices/index.html.erb
+++ b/app/views/practices/index.html.erb
@@ -32,7 +32,8 @@
     <% @practices.each do |practice| %>
       <%= render practice %>
       <p>
-        <%= link_to "編集", edit_practice_path(practice), data: { turbo_frame: "_top" } %>
+        <%= link_to "編集", edit_practice_path(practice), data: { turbo_frame: "_top" } %> |
+        <%= link_to "記録を削除する", practice, data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", turbo_frame: "_top" } %>
       </p>
       <hr>
     <% end %>

--- a/app/views/practices/index.html.erb
+++ b/app/views/practices/index.html.erb
@@ -10,12 +10,12 @@
 <hr>
 
 <%= turbo_frame_tag 'calendar' do %>
-  <%= month_calendar(events: @practices) do |date, practices| %>
+  <%= month_calendar(events: @calendar_displayed_practices) do |date, calendar_displayed_practices| %>
     <%= date.month %>/<%= date.day %>
 
-    <% practices.each do |practice| %>
+    <% calendar_displayed_practices.each do |calendar_displayed_practice| %>
       <div>
-        <%= practice.shooting_count %>射
+        <%= calendar_displayed_practice.shooting_count %>射
       </div>
     <% end %>
   <% end %>

--- a/app/views/practices/index.html.erb
+++ b/app/views/practices/index.html.erb
@@ -1,5 +1,3 @@
-<p style="color: green"><%= notice %></p>
-
 <h1>弓道練習記録帳</h1>
 
 <hr>
@@ -34,7 +32,6 @@
     <% @practices.each do |practice| %>
       <%= render practice %>
       <p>
-        <%= link_to "詳細", practice, data: { turbo_frame: "_top" } %> |
         <%= link_to "編集", edit_practice_path(practice), data: { turbo_frame: "_top" } %>
       </p>
       <hr>

--- a/app/views/practices/index.html.erb
+++ b/app/views/practices/index.html.erb
@@ -15,7 +15,9 @@
 
     <% calendar_displayed_practices.each do |calendar_displayed_practice| %>
       <div>
-        <%= calendar_displayed_practice.shooting_count %>射
+        <%= link_to "#{calendar_displayed_practice.shooting_count}射",
+                    practice_path(calendar_displayed_practice),
+                    data: { turbo: false } %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/practices/index.html.erb
+++ b/app/views/practices/index.html.erb
@@ -17,7 +17,7 @@
       <div>
         <%= link_to "#{calendar_displayed_practice.shooting_count}射",
                     practice_path(calendar_displayed_practice),
-                    data: { turbo: false } %>
+                    data: { turbo_frame: "_top" } %>
       </div>
     <% end %>
   <% end %>
@@ -34,8 +34,8 @@
     <% @practices.each do |practice| %>
       <%= render practice %>
       <p>
-        <%= link_to "詳細", practice, data: { turbo: false} %> |
-        <%= link_to "編集", edit_practice_path(practice), data: { turbo: false} %>
+        <%= link_to "詳細", practice, data: { turbo_frame: "_top" } %> |
+        <%= link_to "編集", edit_practice_path(practice), data: { turbo_frame: "_top" } %>
       </p>
       <hr>
     <% end %>

--- a/app/views/practices/new.html.erb
+++ b/app/views/practices/new.html.erb
@@ -5,5 +5,5 @@
 <br>
 
 <div>
-  <%= link_to "一覧に戻る", practices_path %>
+  <%= link_to "一覧に戻る", practices_path, data: { turbo_frame: "_top" } %>
 </div>

--- a/app/views/practices/show.html.erb
+++ b/app/views/practices/show.html.erb
@@ -4,8 +4,7 @@
     <%= render @practice %>
 
     <div>
-      <%= link_to "編集", edit_practice_path(@practice), data: { turbo_frame: "_top" } %> |
-      <%= link_to "一覧に戻る", practices_path, data: { turbo_frame: "_top" } %>
+      <%= link_to "編集", edit_practice_path(@practice), data: { turbo_frame: "_top" } %>
 
       <%= button_to "記録を削除する", @practice, method: :delete %>
     </div>

--- a/app/views/practices/show.html.erb
+++ b/app/views/practices/show.html.erb
@@ -1,10 +1,13 @@
-<p style="color: green"><%= notice %></p>
+<%= turbo_frame_tag @practice do %>
+  <%= render "modal", title: "詳細" do %>
 
-<%= render @practice %>
+    <%= render @practice %>
 
-<div>
-  <%= link_to "編集", edit_practice_path(@practice) %> |
-  <%= link_to "一覧に戻る", practices_path %>
+    <div>
+      <%= link_to "編集", edit_practice_path(@practice), data: { turbo_frame: "_top" } %> |
+      <%= link_to "一覧に戻る", practices_path, data: { turbo_frame: "_top" } %>
 
-  <%= button_to "記録を削除する", @practice, method: :delete %>
-</div>
+      <%= button_to "記録を削除する", @practice, method: :delete %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/practices/show.html.erb
+++ b/app/views/practices/show.html.erb
@@ -4,9 +4,9 @@
     <%= render @practice %>
 
     <div>
-      <%= link_to "編集", edit_practice_path(@practice), data: { turbo_frame: "_top" } %>
+      <%= link_to "編集", edit_practice_path(@practice), data: { turbo_frame: "_top" } %> |
 
-      <%= button_to "記録を削除する", @practice, method: :delete %>
+      <%= link_to "記録を削除する", @practice, data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？", turbo_frame: "_top" } %>
     </div>
   <% end %>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,6 @@ module KyudoTrainingLog
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.beginning_of_week = :sunday
   end
 end


### PR DESCRIPTION
カレンダーをクリックして過去の記録をモーダル表示できるようにした。
モーダルからは編集画面へ遷移、記録の削除ができるようにした。
カレンダーの表示を日曜始まりに修正した。

## 関連Issue
- #30