### PR TITLE
当月の目標射数が未設定の時に入力リンクが表示されるようにした

### DIFF
--- a/app/models/Target.rb
+++ b/app/models/Target.rb
@@ -1,5 +1,0 @@
-class Target < ApplicationRecord
-  belongs_to :user
-
-  validates :total, numericality: { greater_than_or_equal_to: 0 }
-end

--- a/app/models/target.rb
+++ b/app/models/target.rb
@@ -1,0 +1,5 @@
+class Target < ApplicationRecord
+  belongs_to :user
+
+  validates :total, numericality: { greater_than: 0 }
+end

--- a/app/views/practices/index.html.erb
+++ b/app/views/practices/index.html.erb
@@ -1,16 +1,17 @@
 <h1>弓道練習記録帳</h1>
 
 <hr>
+<%= turbo_frame_tag 'targets_input' do %>
+  <div>
+    <% if @targets.zero? %>
+    <%= link_to "#{Time.current.year}年#{Time.current.month}月の目標を設定する", targets_new_path, data: { turbo_frame: "targets_modal" } %>
+  </div>
+    <% end %>
+<% end %>
+
 <div>
   <%= link_to "今日の練習を記録する", new_practice_path %>
 </div>
-
-<%= turbo_frame_tag 'targets_input' do %>
-  <div>
-    <%= link_to "今月の目標を設定する", targets_new_path, data: { turbo_frame: "targets_modal" } %>
-  </div>
-<% end %>
-
 <hr>
 
 <%= turbo_frame_tag 'calendar' do %>

--- a/app/views/targets/_form.html.erb
+++ b/app/views/targets/_form.html.erb
@@ -14,7 +14,7 @@
 
     <div>
       <%= form.label :total, style: "display: block" %>
-      <%= form.number_field :total, min: 0 %>
+      <%= form.number_field :total, min: 1 %>
     </div>
 
     <div>


### PR DESCRIPTION
当月の目標射数が未設定の時に入力リンクが表示されるようにした。
なお、目標射数を修正できない仕様のため、未来の月の目標は設定できないようにした。
同様に過去の目標も登録・修正できないようにしている。

## 関連Issue
- #55