### PR TITLE
ユーザー認証のバリデーション設定をした

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,12 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :trackable, :confirmable, :lockable, :timeoutable
+
+  validate :password_complexity
+
+  def password_complexity
+    return if password.blank? || password =~ /(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])/
+
+    errors.add :password, 'Complexity requirement not met. Please use: 1 uppercase, 1 lowercase and 1 digit'
+  end
 end

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Resend confirmation instructions</h2>
 
-<%= form_with model: @user, url: confirmation_path(resource_name), local:true do |f| %>
+<%= form_with model: @user, url: confirmation_path(resource_name), data: { turbo: false }, local:true do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,6 +1,6 @@
 <h2>Change your password</h2>
 
-<%= form_with model: @user, url: password_path(resource_name), local: true do |f| %>
+<%= form_with model: @user, url: password_path(resource_name), data: { turbo: false }, local: true do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
   <%= f.hidden_field :reset_password_token %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Forgot your password?</h2>
 
-<%= form_with model: @user, url: password_path(resource_name), local: true do |f| %>
+<%= form_with model: @user, url: password_path(resource_name), data: { turbo: false }, local: true do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,6 +1,6 @@
 <h2>Edit <%= resource_name.to_s.humanize %></h2>
 
-<%= form_with model: @user, url: registration_path(resource_name), local: true do |f| %>
+<%= form_with model: @user, url: registration_path(resource_name), data: { turbo: false }, local: true do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Sign up</h2>
 
-<%= form_with model: @user, url: registration_path(resource_name), local: true do |f| %>
+<%= form_with model: @user, url: registration_path(resource_name), data: { turbo: false }, local: true do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Log in</h2>
 
-<%= form_with model: @user, url: session_path(resource_name), local: true do |f| %>
+<%= form_with model: @user, url: session_path(resource_name), data: { turbo: false }, local: true do |f| %>
   <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Resend unlock instructions</h2>
 
-<%= form_with model: @user, url: unlock_path(resource_name), local: true do |f| %>
+<%= form_with model: @user, url: unlock_path(resource_name), data: { turbo: false }, local: true do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -178,7 +178,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-User.create!(email: 'user1@user.com', password: 'useruser')
+User.create!(email: 'user1@user.com', password: 'Useruser1')
 
 Practice.create!(
   [


### PR DESCRIPTION
- パスワードを8文字以上にし、英大文字・小文字・数字を最低1文字入れることを必須とした。
- Devise関連のエラーメッセージが表示されるようにした。

## 関連Issue
- #52 