### PR TITLE
ログイン失敗時にエラー画面になる問題を修正

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,25 +1,11 @@
 # frozen_string_literal: true
 
 class RegistrationsController < Devise::RegistrationsController
-  def create
-    build_resource(sign_up_params)
-
-    resource.save
+  def destroy
+    resource.destroy
+    Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
+    set_flash_message! :notice, :destroyed
     yield resource if block_given?
-    if resource.persisted?
-      if resource.active_for_authentication?
-        set_flash_message! :notice, :signed_up
-        sign_up(resource_name, resource)
-        respond_with resource, location: after_sign_up_path_for(resource)
-      else
-        set_flash_message! :notice, t('devise.registrations.signed_up_but_inactive')
-        expire_data_after_sign_in!
-        respond_with resource, location: after_inactive_sign_up_path_for(resource)
-      end
-    else
-      clean_up_passwords resource
-      set_minimum_password_length
-      respond_with resource, status: :see_other # 登録失敗時のrespond_withにerror出したいので、ここで303 statusを追加
-    end
+    respond_with_navigational(resource) { redirect_to after_sign_out_path_for(resource_name), status: :see_other, notice: find_message(:destroyed) }
   end
 end

--- a/app/controllers/turbo_devise_controller.rb
+++ b/app/controllers/turbo_devise_controller.rb
@@ -1,0 +1,19 @@
+class TurboDeviseController < ApplicationController
+  class Responder < ActionController::Responder
+    def to_turbo_steam
+      controller.render(options.merge(formats: :html))
+    rescue ActionView::MissingTemplate => error
+      if get?
+        raise error
+      elsif has_errors? && default_action
+        render rendering_options.merge(formats: :html, status: :unprocessable_entity)
+      else
+        redirect_to navigation_location
+      end
+    end
+  end
+
+  self.responder = Responder
+  respond_to :html, :turbo_steam
+
+end

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -2,7 +2,7 @@
   <button type="button" class="col-3 btn btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
     <%= t 'devise.shared.links.when_you_cant_log_in' %>
   </button>
-  <ul class="dropdown-menu col-5 float-end">
+  <ul class="dropdown-menu col-6 float-end">
     <li>
       <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
         <%= link_to t('devise.shared.links.forgot_your_password'), new_password_path(resource_name), class: "dropdown-item" %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+class TurboFailureApp < Devise::FailureApp
+  def respond
+    if request_format = :turbo_stream
+      redirect
+    else
+      super
+    end
+  end
+
+  def slip_format?
+    %w(html turbo_steam */*).include? request_format.to_s
+  end
+end
+
 # Assuming you have not yet modified this file, each configuration option below
 # is set to its default value. Note that some are commented out while others
 # are not: uncommented lines are intended to protect your configuration from
@@ -18,7 +32,7 @@ Devise.setup do |config|
 
   # ==> Controller configuration
   # Configure the parent class to the devise controllers.
-  # config.parent_controller = 'DeviseController'
+  config.parent_controller = 'TurboDeviseController'
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
@@ -277,10 +291,11 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
-  #   manager.intercept_401 = false
-  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+  config.warden do |manager|
+    manager.failure_app = TurboFailureApp
+    #   manager.intercept_401 = false
+    #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,11 @@
 
 Rails.application.routes.draw do
   devise_for :users, controllers: { registrations: 'registrations', sessions: 'sessions' }
+  devise_scope :user do
+    get '/users', to: 'devise/registrations#new'
+    get '/users/password', to: 'devise/passwords#new'
+  end
+
   root to: 'practices#index'
   resources :practices
   resources :targets, only: %i[new create edit update]


### PR DESCRIPTION
ログイン失敗時にエラー画面になる問題を修正した。
また、新規登録・パスワード設定メール送信のエラーが発生した後にリロードするとルーティングエラーが出る問題を修正した。

[【参考】Rails7\+deviseで起こり得るエラーとその対処法 \- Qiita](https://qiita.com/MASAHIDE-HIGASHI/items/1f26c04fb5d5c46ab70b)
[【参考】Failed user registration redirects to /users which isn't a valid get url · Issue \#4573 · heartcombo/devise](https://github.com/heartcombo/devise/issues/4573)

## 関連Issue
- #88 