### PR TITLE
記録の入力・更新・削除を実行した際に、入力・編集・削除をした月のカレンダーを表示するようにした

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -27,10 +27,11 @@ class PracticesController < ApplicationController
 
   def create
     @practice = Practice.new(practice_params)
+    start_date = set_date
 
     respond_to do |format|
       if @practice.save
-        format.html { redirect_to practices_path, notice: t('controllers.practices.create') }
+        format.html { redirect_to root_path(start_date:), notice: t('controllers.practices.create') }
         format.json { render :show, status: :created, location: @practice }
       else
         format.html { render :new, status: :unprocessable_entity }
@@ -40,13 +41,14 @@ class PracticesController < ApplicationController
   end
 
   def update
+    start_date = set_date
     respond_to do |format|
       if @practice.update(practice_params)
         target(@practice.date)
         result(@practice.date)
         set_remaining_to_target
         cancel_target_achievement
-        format.html { redirect_to practices_path, notice: t('controllers.practices.update') }
+        format.html { redirect_to root_path(start_date:), notice: t('controllers.practices.update') }
         format.json { render :show, status: :ok, location: @practice }
       else
         format.html { render :edit, status: :unprocessable_entity }
@@ -57,13 +59,14 @@ class PracticesController < ApplicationController
 
   def destroy
     @practice.destroy
+    start_date = set_date
 
     respond_to do |format|
       target(@practice.date)
       result(@practice.date)
       set_remaining_to_target
       cancel_target_achievement
-      format.html { redirect_to practices_url, notice: t('controllers.practices.destroy'), status: :see_other }
+      format.html { redirect_to root_path(start_date:), notice: t('controllers.practices.destroy'), status: :see_other }
       format.json { head :no_content }
     end
   end
@@ -92,6 +95,10 @@ class PracticesController < ApplicationController
     return if @target_data.blank? || !(@remaining_shots.positive? && (@target_data.first[:achievement] == true))
 
     @target_data.first.update(achievement: false)
+  end
+
+  def set_date
+    [@practice.date.year, @practice.date.mon, @practice.date.day].join('-')
   end
 
   def practice_params

--- a/app/controllers/targets_controller.rb
+++ b/app/controllers/targets_controller.rb
@@ -15,10 +15,10 @@ class TargetsController < ApplicationController
 
     respond_to do |format|
       if @target.save
-        format.html { redirect_to root_path('start_date': start_date), notice: t('controllers.targets.create') }
+        format.html { redirect_to root_path(start_date:), notice: t('controllers.targets.create') }
         format.json { render :show, status: :created, location: @target }
       else
-        format.html { redirect_to root_path('start_date': start_date), status: :unprocessable_entity, alert: t('controllers.targets.create_error') }
+        format.html { redirect_to root_path(start_date:), status: :unprocessable_entity, alert: t('controllers.targets.create_error') }
         format.json { render json: @target.errors, status: :unprocessable_entity }
       end
     end
@@ -31,10 +31,10 @@ class TargetsController < ApplicationController
 
     respond_to do |format|
       if @target.update(target_params)
-        format.html { redirect_to root_path('start_date': start_date), notice: notice_message }
+        format.html { redirect_to root_path(start_date:), notice: notice_message }
         format.json { render :show, status: :ok, location: @target }
       else
-        format.html { redirect_to root_path('start_date': start_date), status: :unprocessable_entity, alert: t('controllers.targets.update_error') }
+        format.html { redirect_to root_path(start_date:), status: :unprocessable_entity, alert: t('controllers.targets.update_error') }
         format.json { render json: @target.errors, status: :unprocessable_entity }
       end
     end

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -17,7 +17,7 @@
   <% end %>
 
   <div class="text-center my-4">
-    <%= link_to t('devise.shared.links.back'), practices_path, class: "btn btn-outline-primary col-3 text-wrap" %>
+    <%= link_to t('devise.shared.links.back'), root_path, class: "btn btn-outline-primary col-3 text-wrap" %>
   </div>
 
   <div class="text-center my-3">

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -28,7 +28,7 @@
   <% end %>
 
   <div class="text-center my-4">
-    <%= link_to t('devise.shared.links.back'), practices_path, class: "btn btn-outline-primary col-3 text-wrap" %>
+    <%= link_to t('devise.shared.links.back'), root_path, class: "btn btn-outline-primary col-3 text-wrap" %>
   </div>
 
   <div class="text-center my-3">

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -17,7 +17,7 @@
   <% end %>
 
   <div class="text-center my-4">
-    <%= link_to t('devise.shared.links.back'), practices_path, class: "btn btn-outline-primary col-3 text-wrap" %>
+    <%= link_to t('devise.shared.links.back'), root_path, class: "btn btn-outline-primary col-3 text-wrap" %>
   </div>
 
   <div class="text-center my-3">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -49,7 +49,7 @@
   <% end %>
 
   <div class="text-center mb-4">
-    <%= link_to t('devise.shared.links.back'), practices_path, class: "btn btn-outline-primary col-3 text-wrap" %>
+    <%= link_to t('devise.shared.links.back'), root_path, class: "btn btn-outline-primary col-3 text-wrap" %>
   </div>
 
   <div class="mt-4 row justify-content-center">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -34,6 +34,6 @@
   <% end %>
 
   <div class="text-center mb-4">
-    <%= link_to t('devise.shared.links.back'), practices_path, class: "btn btn-outline-primary col-3 text-wrap" %>
+    <%= link_to t('devise.shared.links.back'), root_path, class: "btn btn-outline-primary col-3 text-wrap" %>
   </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -32,7 +32,7 @@
   <% end %>
 
   <div class="text-center my-4">
-    <%= link_to t('devise.shared.links.back'), practices_path, class: "btn btn-outline-primary col-3 text-wrap" %>
+    <%= link_to t('devise.shared.links.back'), root_path, class: "btn btn-outline-primary col-3 text-wrap" %>
   </div>
 
   <div class="text-center my-3">

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -17,7 +17,7 @@
   <% end %>
 
   <div class="text-center my-4">
-    <%= link_to t('devise.shared.links.back'), practices_path, class: "btn btn-outline-primary col-3 text-wrap" %>
+    <%= link_to t('devise.shared.links.back'), root_path, class: "btn btn-outline-primary col-3 text-wrap" %>
   </div>
 
   <div class="text-center my-3">

--- a/app/views/practices/_tabs.html.erb
+++ b/app/views/practices/_tabs.html.erb
@@ -1,9 +1,9 @@
 <ul class="nav nav-tabs">
   <li class="nav-item" data-bs-toggle="tab" >
-    <%= link_to t('views.tab.all'), practices_path(memos: 'all'), class: "nav-link #{current_page_tab_or_not('all')}" %>
+    <%= link_to t('views.tab.all'), root_path(memos: 'all'), class: "nav-link #{current_page_tab_or_not('all')}" %>
   </li>
 
   <li class="nav-item" data-bs-toggle="tab">
-    <%= link_to t('views.tab.important'), practices_path(memos: 'important'), class: "nav-link #{current_page_tab_or_not('important')}" %>
+    <%= link_to t('views.tab.important'), root_path(memos: 'important'), class: "nav-link #{current_page_tab_or_not('important')}" %>
   </li>
 </ul>

--- a/app/views/practices/edit.html.erb
+++ b/app/views/practices/edit.html.erb
@@ -8,6 +8,6 @@
   </div>
 
   <div class="text-center mb-3">
-    <%= link_to t('views.common.back'), practices_path, data: { turbo_frame: "_top" }, class: "btn btn-outline-primary col-3 text-wrap" %>
+    <%= link_to t('views.common.back'), root_path(start_date: [@practice.date.year, @practice.date.mon, @practice.date.day].join('-')), data: { turbo_frame: "_top" }, class: "btn btn-outline-primary col-3 text-wrap" %>
   </div>
 </div>

--- a/app/views/practices/new.html.erb
+++ b/app/views/practices/new.html.erb
@@ -4,6 +4,6 @@
   <%= render "form", practice: @practice %>
 
   <div class="text-center mb-3">
-    <%= link_to t('views.common.back'), practices_path, data: { turbo_frame: "_top" }, class: "btn btn-outline-primary col-3 text-wrap" %>
+    <%= link_to t('views.common.back'), root_path, data: { turbo_frame: "_top" }, class: "btn btn-outline-primary col-3 text-wrap" %>
   </div>
 </div>


### PR DESCRIPTION
記録の入力・更新・削除を実行した際に、入力・編集・削除をした月のカレンダーを表示するようにした。
また、記録編集画面から戻るボタンを押した際に、元の月のカレンダーを表示するようにした。
タブと戻るボタンのリンク先が`practices_path`だったのを`root_path`に修正した。

## 関連Issue
- #98 