### PR TITLE
記録の射数表示を修正した

### DIFF
--- a/app/views/practices/index.html.erb
+++ b/app/views/practices/index.html.erb
@@ -6,7 +6,7 @@
       <% calendar_displayed_practices.each do |calendar_displayed_practice| %>
         <div>
           <% calendar_displayed_practice.shooting_count ||= 0 %>
-          <%= link_to t('views.index.shooting_counts', count: calendar_displayed_practice.shooting_count),
+          <%= link_to "#{calendar_displayed_practice.shooting_count}",
                       practice_path(calendar_displayed_practice),
                       data: { turbo_frame: "practices_modal" } %>
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -238,7 +238,7 @@ en:
       no_target: Targets not input.
       remaining_shots: "Remained:%{count}shots"
       result: Result
-      shooting_counts: "%{count}"
+      shooting_counts: "%{count}shots"
       target: Target
       target_input: "Target inputs for %{year}-%{month}"
       target_edit: "Target edits"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -204,7 +204,7 @@ ja:
       no_target: 目標射数が入力されていません
       remaining_shots: "目標達成まで　%{count}射"
       result: 現在
-      shooting_counts: "%{count}"
+      shooting_counts: "%{count}射"
       target: 目標
       target_input: "%{year}年%{month}月の目標を入力"
       target_edit: "目標を修正"


### PR DESCRIPTION
記録の射数表示（記録一覧、詳細モーダル）から○○射の「射」が抜けていたので修正した。