### PR TITLE
本番環境で確認メールが送信されないのを修正した

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@
 !/app/assets/builds/.keep
 
 /node_modules
+
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -55,11 +55,11 @@ gem 'bootsnap', require: false
 
 gem 'devise'
 gem 'devise-i18n'
+gem 'dotenv-rails'
 gem 'i18n_generators'
 gem 'kaminari'
 gem 'meta-tags'
 gem 'simple_calendar', '~> 2.4'
-gem 'dotenv-rails'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ gem 'i18n_generators'
 gem 'kaminari'
 gem 'meta-tags'
 gem 'simple_calendar', '~> 2.4'
+gem 'dotenv-rails'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,10 @@ GEM
       devise (>= 4.8.0)
     diff-lcs (1.5.0)
     digest (3.1.0)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     erubi (1.11.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -324,6 +328,7 @@ DEPENDENCIES
   debug
   devise
   devise-i18n
+  dotenv-rails
   factory_bot_rails
   i18n_generators
   jsbundling-rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,4 +90,16 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+  config.action_mailer.default_url_options = { host: 'kyudo-training-log.com' }
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: 'smtp.gmail.com',
+    domain: 'gmail.com',
+    port: 587,
+    user_name: ENV['SEND_MAIL'],
+    password: ENV['GMAIL_SPECIFIC_PASSWORD'],
+    authentication: :login,
+    enable_starttls_auto: true
+  }
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -38,7 +38,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = ENV['SEND_MAIL']
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -38,7 +38,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = ENV['SEND_MAIL']
+  config.mailer_sender = 'kyudo.training.log@gmail.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'


### PR DESCRIPTION
本番環境のメール送信設定が漏れていたため、送信できていなかった。
送信用のGmailを取得し送信設定をした。

## 関連Issue
- #137 